### PR TITLE
phpunit 9 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .DS_Store
 composer.lock
+.phpunit.result.cache

--- a/tests/LiveWebsites.php
+++ b/tests/LiveWebsites.php
@@ -6,7 +6,7 @@
   This file is not run by default using phpunit, but you can run it manually:
   $ phpunit.phar tests/LiveWebsites.php
 */
-class LiveWebsites extends PHPUnit_Framework_TestCase {
+class LiveWebsites extends \PHPUnit\Framework\TestCase {
 
   private function parse($url) {
     return Mf2\fetch($url);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1,5 +1,5 @@
 <?php
-class ParserTest extends PHPUnit_Framework_TestCase {
+class ParserTest extends \PHPUnit\Framework\TestCase {
 
   public function testFindHCardOnProperty() {
     $html = '<a href="http://example.com" class="h-card">Example</a>

--- a/tests/RepresentativeTest.php
+++ b/tests/RepresentativeTest.php
@@ -1,5 +1,5 @@
 <?php
-class RepresentativeTest extends PHPUnit_Framework_TestCase {
+class RepresentativeTest extends \PHPUnit\Framework\TestCase {
 
   public function testNoHCard() {
     $html = '<a href="http://example.com/">Example</a>';
@@ -12,7 +12,7 @@ class RepresentativeTest extends PHPUnit_Framework_TestCase {
     $html = '<div class="h-card"><a href="http://example.com/" class="u-url u-uid">Example</a></div>';
     $parsed = Mf2\parse($html);
     $representative = Mf2\HCard\representative($parsed, 'http://example.com/');
-    $this->assertInternalType('array', $representative);
+    $this->assertIsArray($representative);
     $this->assertContains('http://example.com/', $representative['properties']['url']);
   }
 
@@ -20,7 +20,7 @@ class RepresentativeTest extends PHPUnit_Framework_TestCase {
     $html = '<div class="h-card"><a href="http://example.com/" class="u-url" rel="me">Example</a></div>';
     $parsed = Mf2\parse($html);
     $representative = Mf2\HCard\representative($parsed, 'http://alternate.example.net/'); // different page URL than the h-card URL
-    $this->assertInternalType('array', $representative);
+    $this->assertIsArray($representative);
     $this->assertContains('http://example.com/', $representative['properties']['url']);
   }
 

--- a/tests/URLTest.php
+++ b/tests/URLTest.php
@@ -1,5 +1,5 @@
 <?php
-class URLTest extends PHPUnit_Framework_TestCase {
+class URLTest extends \PHPUnit\Framework\TestCase {
 
   public function testURLsMatch() {
     $url1 = 'http://example.com/?';


### PR DESCRIPTION
Cloned this package from GitHub and Installed fresh with `composer install` on PHP 7.4.33. (PHP installed via ondrej ubuntu PPA).

PHP8+ has other issues!

Because we have no `composer.lock` here, composer grabs the latest version of each packages that works with your PHP version. On PHP 7.4, that got me PHPUnit 9.6.8.

PHPUnit moved to namespaced (rather than underscored) class names some time ago (version 6?) , so these tests that inherit from `PHPUnit_Framework_TestCase` all needed updating.

I've also added `.phpunit.result.cache` (which appeared on my system when running these test) to .gitignore.

## How to Test

On a system with PHP7.4, with dependencies installed via `composer install`, run all the tests

- `./bin/vendor/phpunit`
- `./bin/vendor/phpunit tests/LiveWebsites.php`  (this isn't run by default)

Before this patch: PHPUnit runs die with `PHP Fatal error:  Uncaught Error: Class 'PHPUnit_Framework_TestCase' not found`

After this patch: tests run successfully.