### PR TITLE
allow no-path URL to match `/` path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .DS_Store
 composer.lock
+.phpunit.result.cache

--- a/src/mf2/representative-h-card.php
+++ b/src/mf2/representative-h-card.php
@@ -95,7 +95,7 @@ function has_value($item, $property, $value) {
   if(!is_microformat($item)) return false;
   if(!array_key_exists($property, $item['properties'])) return false;
   foreach($item['properties'][$property] as $v) {
-    if($v == $value) {
+    if(urls_match($v, $value)) {
       return true;
     }
   }
@@ -107,7 +107,7 @@ function has_rel($parsed, $property, $value) {
   if(!array_key_exists('rels', $parsed)) return false;
   if(!array_key_exists($property, $parsed['rels'])) return false;
   foreach($parsed['rels'][$property] as $v) {
-    if($v == $value) {
+    if(urls_match($v, $value)) {
       return true;
     }
   }

--- a/tests/LiveWebsites.php
+++ b/tests/LiveWebsites.php
@@ -6,7 +6,7 @@
   This file is not run by default using phpunit, but you can run it manually:
   $ phpunit.phar tests/LiveWebsites.php
 */
-class LiveWebsites extends PHPUnit_Framework_TestCase {
+class LiveWebsites extends \PHPUnit\Framework\TestCase {
 
   private function parse($url) {
     return Mf2\fetch($url);

--- a/tests/LiveWebsites.php
+++ b/tests/LiveWebsites.php
@@ -33,4 +33,10 @@ class LiveWebsites extends \PHPUnit\Framework\TestCase {
     $this->assertContains('http://gregorlove.com/', $representative['properties']['url']);
   }
 
+  public function testAndreasVos() {
+    $url = 'https://avris.it/';
+    $parsed = $this->parse($url);
+    $representative = Mf2\HCard\representative($parsed, $url);
+    $this->assertContains('https://avris.it/', $representative['properties']['url']);
+  }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -1,5 +1,5 @@
 <?php
-class ParserTest extends PHPUnit_Framework_TestCase {
+class ParserTest extends \PHPUnit\Framework\TestCase {
 
   public function testFindHCardOnProperty() {
     $html = '<a href="http://example.com" class="h-card">Example</a>

--- a/tests/RepresentativeTest.php
+++ b/tests/RepresentativeTest.php
@@ -16,6 +16,14 @@ class RepresentativeTest extends \PHPUnit\Framework\TestCase {
     $this->assertContains('http://example.com/', $representative['properties']['url']);
   }
 
+  public function testTopLevelHCardWithURLUIDMissingPath() {
+    $html = '<div class="h-card"><a href="http://example.com" class="u-url u-uid">Example</a></div>';
+    $parsed = Mf2\parse($html);
+    $representative = Mf2\HCard\representative($parsed, 'http://example.com/');
+    $this->assertIsArray($representative);
+    $this->assertContains('http://example.com', $representative['properties']['url']);
+  }
+
   public function testTopLevelHCardURLWithRelMe() {
     $html = '<div class="h-card"><a href="http://example.com/" class="u-url" rel="me">Example</a></div>';
     $parsed = Mf2\parse($html);

--- a/tests/RepresentativeTest.php
+++ b/tests/RepresentativeTest.php
@@ -1,5 +1,5 @@
 <?php
-class RepresentativeTest extends PHPUnit_Framework_TestCase {
+class RepresentativeTest extends \PHPUnit\Framework\TestCase {
 
   public function testNoHCard() {
     $html = '<a href="http://example.com/">Example</a>';
@@ -12,7 +12,7 @@ class RepresentativeTest extends PHPUnit_Framework_TestCase {
     $html = '<div class="h-card"><a href="http://example.com/" class="u-url u-uid">Example</a></div>';
     $parsed = Mf2\parse($html);
     $representative = Mf2\HCard\representative($parsed, 'http://example.com/');
-    $this->assertInternalType('array', $representative);
+    $this->assertIsArray($representative);
     $this->assertContains('http://example.com/', $representative['properties']['url']);
   }
 
@@ -20,7 +20,7 @@ class RepresentativeTest extends PHPUnit_Framework_TestCase {
     $html = '<div class="h-card"><a href="http://example.com/" class="u-url" rel="me">Example</a></div>';
     $parsed = Mf2\parse($html);
     $representative = Mf2\HCard\representative($parsed, 'http://alternate.example.net/'); // different page URL than the h-card URL
-    $this->assertInternalType('array', $representative);
+    $this->assertIsArray($representative);
     $this->assertContains('http://example.com/', $representative['properties']['url']);
   }
 

--- a/tests/URLTest.php
+++ b/tests/URLTest.php
@@ -1,5 +1,5 @@
 <?php
-class URLTest extends PHPUnit_Framework_TestCase {
+class URLTest extends \PHPUnit\Framework\TestCase {
 
   public function testURLsMatch() {
     $url1 = 'http://example.com/?';


### PR DESCRIPTION
Caveat / sorry, this includes the PHPUnit-appeasing changes I made in #2 so I suggest we address that first!

# The issue

This was found while trying to parse Andreas Vos' personal site https://avris.it/ . It has an h-card ([pin13 mf2 parse here](http://pin13.net/mf2/?url=https%3A%2F%2Favris.it%2F)) with:

- no `uid` (so we can't compare `url` and `uid`)
- no `rel=me` that matches the page URL (so step two fails)
-  `url` `https://avris.it`. so the "one single h-card with `url` matching the page URL should work. however, this `url` value has no path, which means direct comparison `'https://avris.it'` === 'https://avris.it/'` fails. In the end, `representative` doesn't find this h-card

I notice that we already have a `Mf2\HCard\urls_match` function (tested in `tests/URLTest.php`), along with this comment:

```
// For the purposes of this library, if there is no path, the '/' path is automatically added.
// This means http://example.com and http://example.com/ are equivalent
```

However, in `has_value` and `rel_value` we were still doing strict equality.

# This fix

Replace the exact value matching for `has_value` and `rel_value` with `urls_match`.

# Tests

Added new test case in `tests/RepresentativeTest.php` and added Andreas' site to `tests/LiveWebsites.php`