### PR TITLE
build_url: treat empty fragment/query as absent

### DIFF
--- a/src/mf2/representative-h-card.php
+++ b/src/mf2/representative-h-card.php
@@ -130,8 +130,8 @@ function build_url($parsed_url) {
   $pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass']  : '';
   $pass     = ($user || $pass) ? "$pass@" : '';
   $path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
-  $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
-  $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+  $query    = !empty($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+  $fragment = !empty($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
   return "$scheme$user$pass$host$port$path$query$fragment";
 }
 


### PR DESCRIPTION
Closes #4 

Since PHP 8.0 `parse_url` treats missing query and fragment as null and empty query (`?` with no args) and fragment (`#` with no following chars) as an empty string.

Before this PR: `./vendor/bin/phpunit` fails on `URLTest::testURLsMatch` when run on PHP8+

After this PR: test passes. Fix should work on all supported earlier versions, as well! Tested under 8.1 and 7.4.